### PR TITLE
Human copyable deps format

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ Add AMQP as a dependency in your `mix.exs` file.
 
 ```elixir
 def deps do
-  [{:amqp, "~> 1.3"}]
+  [
+    {:amqp, "~> 1.3"}
+  ]
 end
 ```
 


### PR DESCRIPTION
The previous version of formatting causes difficulties when trying to copy a line with a double click.
After inserting into the code, you have to delete parentheses.
In my opinion, this formatting option is more convenient and adapted for copy paste.